### PR TITLE
グラフの縦軸に関して、表記の変更

### DIFF
--- a/src/components/pension/PensionChartInner.tsx
+++ b/src/components/pension/PensionChartInner.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { CartesianGrid, Legend, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
-import { formatYen } from "@/lib/format-yen";
+import { formatYen, formatYenGroupedDigits } from "@/lib/format-yen";
 import { AGE_END, AGE_START } from "./pension-defaults";
 
 export type ChartRow = {
@@ -23,7 +23,7 @@ export function PensionChartInner({ chartData, startAgeYears }: PensionChartInne
         >
             <LineChart
                 data={chartData}
-                margin={{ top: 8, right: 8, left: 8, bottom: 28 }}
+                margin={{ top: 12, right: 12, left: 12, bottom: 28 }}
             >
                 <CartesianGrid
                     strokeDasharray="3 3"
@@ -37,9 +37,10 @@ export function PensionChartInner({ chartData, startAgeYears }: PensionChartInne
                     label={{ value: "年齢（歳）", position: "insideBottom", offset: -4 }}
                 />
                 <YAxis
-                    tickFormatter={(v) => `${Math.round(v / 1_000_000)}M`}
-                    tick={{ fontSize: 12 }}
-                    width={48}
+                    tickFormatter={(v) => formatYenGroupedDigits(Number(v))}
+                    tick={{ fontSize: 11 }}
+                    width={92}
+                    tickMargin={8}
                 />
                 <Tooltip
                     formatter={(value: number) => formatYen(value)}

--- a/src/lib/format-yen.ts
+++ b/src/lib/format-yen.ts
@@ -1,3 +1,14 @@
+const groupedDigitsFormatter = new Intl.NumberFormat("ja-JP", {
+    useGrouping: true,
+    maximumFractionDigits: 0,
+    minimumFractionDigits: 0,
+});
+
+/** 円の金額を、桁区切り（例: 150,000）のみで表す（縦軸など・通貨記号なし） */
+export function formatYenGroupedDigits(n: number): string {
+    return groupedDigitsFormatter.format(Math.round(n));
+}
+
 export function formatYen(n: number): string {
     return new Intl.NumberFormat("ja-JP", {
         style: "currency",


### PR DESCRIPTION
## 概要
PensionChartのY軸表示を改善し、`format-yen`ライブラリに桁区切りフォーマット関数を追加しました。

## 背景
Y軸の表示が`M`単位で丸められていて見づらかった。円金額の表示整合性のため、既存の`formatYen`に加えてガイド付きの桁区切り表示を共通化したかった。

## 変更内容
- format-yen.ts
  - 新関数 `formatYenGroupedDigits(n: number): string` を追加
  - `Intl.NumberFormat("ja-JP")`により `123,456` のような桁区切り表示（通貨記号なし）
- PensionChartInner.tsx
  - `formatYenGroupedDigits`をインポート
  - `LineChart`の`margin`を`8`→`12`に調整
  - `YAxis`の`tickFormatter`を`M`省略表現から`formatYenGroupedDigits`に変更
  - `YAxis`の`tick`サイズを`12`→`11`
  - `YAxis`の`width`を`48`→`92`、`tickMargin`を`8`追加
  - `Tooltip`は引き続き `formatYen` を利用

## 動作確認
- `npm run dev`で表示確認（Y軸が桁区切り表示）
- `npm run build`でビルド成功
- Pension chartのレイアウトが崩れていないこと確認
- ツールチップは`¥`付き通貨表示のまま確認