### PR TITLE
スライダーの位置調整及びメモリの変更

### DIFF
--- a/src/components/pension/PensionForm.tsx
+++ b/src/components/pension/PensionForm.tsx
@@ -21,12 +21,12 @@ export type PensionFormProps = {
     onLifeInsurance: (n: number) => void;
     medicalExpense: number;
     onMedicalExpense: (n: number) => void;
-    startAgeYears: number;
-    onStartAgeYears: (n: number) => void;
+    startAgeMonths: number;
+    onStartAgeMonths: (n: number) => void;
     slideFactorPercentLabel: string;
 };
 
-export function PensionForm({ preset, onPreset, basic, onBasic, employee, onEmployee, spousePension, onSpousePension, hasSpouse, onHasSpouse, spouseIncome, onSpouseIncome, householdSize, onHouseholdSize, lifeInsurance, onLifeInsurance, medicalExpense, onMedicalExpense, startAgeYears, onStartAgeYears, slideFactorPercentLabel }: PensionFormProps) {
+export function PensionForm({ preset, onPreset, basic, onBasic, employee, onEmployee, spousePension, onSpousePension, hasSpouse, onHasSpouse, spouseIncome, onSpouseIncome, householdSize, onHouseholdSize, lifeInsurance, onLifeInsurance, medicalExpense, onMedicalExpense, startAgeMonths, onStartAgeMonths, slideFactorPercentLabel }: PensionFormProps) {
     return (
         <div className="space-y-6 rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
             <h2 className="text-lg font-medium text-slate-800">入力</h2>
@@ -146,23 +146,6 @@ export function PensionForm({ preset, onPreset, basic, onBasic, employee, onEmpl
                         onChange={(e) => onMedicalExpense(Number(e.target.value) || 0)}
                     />
                 </label>
-            </div>
-
-            <div>
-                <div className="mb-2 flex justify-between text-sm text-slate-600">
-                    <span className="font-medium text-slate-700">受給開始年齢</span>
-                    <span className="tabular-nums">{startAgeYears}歳</span>
-                </div>
-                <input
-                    type="range"
-                    min={60}
-                    max={75}
-                    step={1}
-                    value={startAgeYears}
-                    onChange={(e) => onStartAgeYears(Number(e.target.value))}
-                    className="w-full accent-slate-900"
-                />
-                <p className="mt-1 text-xs text-slate-500">繰上げは月あたり −0.4%、繰下げは +0.7%（65歳満額比）。係数: {slideFactorPercentLabel}</p>
             </div>
         </div>
     );

--- a/src/components/pension/PensionSimulator.tsx
+++ b/src/components/pension/PensionSimulator.tsx
@@ -20,7 +20,9 @@ export function PensionSimulator() {
     const [householdSize, setHouseholdSize] = useState(defaultPensionInput.family.householdSize);
     const [lifeInsurance, setLifeInsurance] = useState(defaultPensionInput.insurance.lifeInsurance);
     const [medicalExpense, setMedicalExpense] = useState(defaultPensionInput.insurance.medicalExpense);
-    const [startAgeYears, setStartAgeYears] = useState(65);
+    const [startAgeMonths, setStartAgeMonths] = useState(65 * 12);
+
+    const startAgeYears = startAgeMonths / 12;
 
     const input: UserInput = useMemo(
         () => ({
@@ -77,6 +79,24 @@ export function PensionSimulator() {
 
             <section className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
                 <h2 className="mb-4 text-lg font-medium text-slate-800">累積手取りの推移</h2>
+                <div className="mb-4 rounded-lg border border-slate-200 bg-slate-50 p-4">
+                    <div className="mb-2 flex justify-between text-sm text-slate-600">
+                        <span className="font-medium text-slate-700">受給開始年齢</span>
+                        <span className="tabular-nums">
+                            {Math.floor(startAgeYears)}歳{startAgeMonths % 12}か月
+                        </span>
+                    </div>
+                    <input
+                        type="range"
+                        min={60 * 12}
+                        max={75 * 12}
+                        step={1}
+                        value={startAgeMonths}
+                        onChange={(e) => setStartAgeMonths(Number(e.target.value))}
+                        className="w-full accent-slate-900"
+                    />
+                    <p className="mt-1 text-xs text-slate-500">繰上げは月あたり −0.4%、繰下げは +0.7%（65歳満額比）。係数: {(slideFactor * 100).toFixed(2)}%</p>
+                </div>
                 <div className="h-[500px] w-full min-w-0">
                     <PensionChart
                         chartData={chartData}
@@ -105,8 +125,8 @@ export function PensionSimulator() {
                     onLifeInsurance={setLifeInsurance}
                     medicalExpense={medicalExpense}
                     onMedicalExpense={setMedicalExpense}
-                    startAgeYears={startAgeYears}
-                    onStartAgeYears={setStartAgeYears}
+                    startAgeMonths={startAgeMonths}
+                    onStartAgeMonths={setStartAgeMonths}
                     slideFactorPercentLabel={`${(slideFactor * 100).toFixed(2)}%`}
                 />
 

--- a/src/lib/calculations.ts
+++ b/src/lib/calculations.ts
@@ -17,7 +17,7 @@ export type UserInput = {
         lifeInsurance: number;
         medicalExpense: number;
     };
-    /** 受給開始年齢（60〜75・整数年） */
+    /** 受給開始年齢（60〜75、1か月ごとに指定） */
     startAgeYears: number;
 };
 


### PR DESCRIPTION
## 概要
グラフ画面の「受給開始年齢」操作系をグラフ上（グラフセクション直上）に移動し、年齢スライダーを「1か月ごと」に切り替えました。これで、ユーザーが設計書にある要件どおり月単位で開始年齢を調整できるようになっています。

## 背景
既存実装では `PensionForm` 内に受給開始年齢スライダーがあって、グラフ配置との距離がありました。設計書から「受給開始年齢は1か月ごと」と指定されているため、年単位ステップ（step=1）では不十分でした。

## 変更内容
- calculations.ts
  - `UserInput.startAgeYears` のコメントを更新
    - `60〜75、1か月ごとに指定`（年単位とは明示的に区別）
- PensionSimulator.tsx
  - 状態を `startAgeYears` → `startAgeMonths` に変更（初期 `65*12`）
  - `startAgeYears = startAgeMonths / 12` を算出し、既存計算関数へ渡す
  - グラフ表示セクション内に新スライダーブロックを追加
    - `min=60*12`, `max=75*12`, `step=1`
    - ラベル表示：`{Math.floor(startAgeYears)}歳{startAgeMonths % 12}か月`
    - 補足文：`繰上げ-0.4%/月、繰下げ+0.7%/月、係数は現在表示`
  - `PensionForm` へは `startAgeMonths`, `onStartAgeMonths` を渡す
- PensionForm.tsx
  - `PensionFormProps` に `startAgeMonths`, `onStartAgeMonths` を追加
  - 受給開始年齢スライダーブロックを削除（グラフ上へ移動）
- ビルド確認
  - `npm run build` 成功（Next.js production build OK）

## 動作確認
- ✅ `npm run dev` で起動し、グラフ上部に受給開始年齢スライダーが見えることを確認
- ✅ スライダー操作で「年+月」の表示が切り替わることを確認
- ✅ 65歳基準比較グラフの挙動（累積手取り）に影響なく更新されることを確認
- ✅ `npm run build` でビルド成功（エラーなし）

