### PR TITLE
配偶者ありチェックボックスを削除し、hasSpouse をプリセット由来の派生値に変更

### DIFF
--- a/src/components/pension/PensionForm.tsx
+++ b/src/components/pension/PensionForm.tsx
@@ -11,8 +11,6 @@ export type PensionFormProps = {
     onEmployee: (n: number) => void;
     spousePension: number;
     onSpousePension: (n: number) => void;
-    hasSpouse: boolean;
-    onHasSpouse: (v: boolean) => void;
     spouseIncome: number;
     onSpouseIncome: (n: number) => void;
     householdSize: number;
@@ -21,12 +19,11 @@ export type PensionFormProps = {
     onLifeInsurance: (n: number) => void;
     medicalExpense: number;
     onMedicalExpense: (n: number) => void;
-    startAgeMonths: number;
-    onStartAgeMonths: (n: number) => void;
-    slideFactorPercentLabel: string;
 };
 
-export function PensionForm({ preset, onPreset, basic, onBasic, employee, onEmployee, spousePension, onSpousePension, hasSpouse, onHasSpouse, spouseIncome, onSpouseIncome, householdSize, onHouseholdSize, lifeInsurance, onLifeInsurance, medicalExpense, onMedicalExpense, startAgeMonths, onStartAgeMonths, slideFactorPercentLabel }: PensionFormProps) {
+export function PensionForm({ preset, onPreset, basic, onBasic, employee, onEmployee, spousePension, onSpousePension, spouseIncome, onSpouseIncome, householdSize, onHouseholdSize, lifeInsurance, onLifeInsurance, medicalExpense, onMedicalExpense }: PensionFormProps) {
+    const hasSpouse = preset !== "single";
+
     return (
         <div className="space-y-6 rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
             <h2 className="text-lg font-medium text-slate-800">入力</h2>
@@ -91,14 +88,6 @@ export function PensionForm({ preset, onPreset, basic, onBasic, employee, onEmpl
 
             <div className="space-y-3">
                 <p className="text-sm font-medium text-slate-700">世帯情報</p>
-                <label className="flex items-center gap-2 text-sm text-slate-600">
-                    <input
-                        type="checkbox"
-                        checked={hasSpouse}
-                        onChange={(e) => onHasSpouse(e.target.checked)}
-                    />
-                    配偶者あり
-                </label>
                 {hasSpouse && (
                     <label className="block text-sm text-slate-600">
                         配偶者所得（年額・円）

--- a/src/components/pension/PensionSimulator.tsx
+++ b/src/components/pension/PensionSimulator.tsx
@@ -15,7 +15,7 @@ export function PensionSimulator() {
     const [basic, setBasic] = useState(defaultPensionInput.pension.basic);
     const [employee, setEmployee] = useState(defaultPensionInput.pension.employee);
     const [spousePension, setSpousePension] = useState(defaultPensionInput.pension.spousePension ?? 0);
-    const [hasSpouse, setHasSpouse] = useState(defaultPensionInput.family.hasSpouse);
+    const hasSpouse = preset !== "single";
     const [spouseIncome, setSpouseIncome] = useState(defaultPensionInput.family.spouseIncome);
     const [householdSize, setHouseholdSize] = useState(defaultPensionInput.family.householdSize);
     const [lifeInsurance, setLifeInsurance] = useState(defaultPensionInput.insurance.lifeInsurance);
@@ -56,7 +56,6 @@ export function PensionSimulator() {
     const applyPreset = (p: FamilyPreset) => {
         setPreset(p);
         const f = applyFamilyPreset(p);
-        setHasSpouse(f.hasSpouse);
         setSpouseIncome(f.spouseIncome);
         setHouseholdSize(f.householdSize);
     };
@@ -139,8 +138,6 @@ export function PensionSimulator() {
                     onEmployee={setEmployee}
                     spousePension={spousePension}
                     onSpousePension={setSpousePension}
-                    hasSpouse={hasSpouse}
-                    onHasSpouse={setHasSpouse}
                     spouseIncome={spouseIncome}
                     onSpouseIncome={setSpouseIncome}
                     householdSize={householdSize}
@@ -149,9 +146,6 @@ export function PensionSimulator() {
                     onLifeInsurance={setLifeInsurance}
                     medicalExpense={medicalExpense}
                     onMedicalExpense={setMedicalExpense}
-                    startAgeMonths={startAgeMonths}
-                    onStartAgeMonths={setStartAgeMonths}
-                    slideFactorPercentLabel={`${(slideFactor * 100).toFixed(2)}%`}
                 />
 
                 <div className="space-y-6">

--- a/src/lib/calculations.ts
+++ b/src/lib/calculations.ts
@@ -270,15 +270,15 @@ export function buildChartRows(results65: MonthlyResult[], resultsSlide: Monthly
     return rows;
 }
 
-export function applyFamilyPreset(preset: FamilyPreset): Pick<UserInput["family"], "hasSpouse" | "spouseIncome" | "householdSize"> {
+export function applyFamilyPreset(preset: FamilyPreset): Pick<UserInput["family"], "spouseIncome" | "householdSize"> {
     switch (preset) {
         case "single":
-            return { hasSpouse: false, spouseIncome: 0, householdSize: 1 };
+            return { spouseIncome: 0, householdSize: 1 };
         case "singleEarner":
-            return { hasSpouse: true, spouseIncome: 0, householdSize: 2 };
+            return { spouseIncome: 0, householdSize: 2 };
         case "dualIncome":
-            return { hasSpouse: true, spouseIncome: 2_000_000, householdSize: 2 };
+            return { spouseIncome: 2_000_000, householdSize: 2 };
         default:
-            return { hasSpouse: false, spouseIncome: 0, householdSize: 1 };
+            return { spouseIncome: 0, householdSize: 1 };
     }
 }

--- a/年金シミュレーター.md
+++ b/年金シミュレーター.md
@@ -61,7 +61,6 @@
 
 | 項目     | 型       |
 | ------ | ------- |
-| 配偶者の有無 | boolean |
 | 配偶者所得  | number  |
 | 世帯人数   | number  |
 
@@ -231,7 +230,7 @@ type UserInput = {
     spousePension?: number;
   };
   family: {
-    hasSpouse: boolean;
+    hasSpouse: boolean; // 世帯タイプのプリセット（独身/夫婦）から導出。ユーザーが直接入力する値ではない
     spouseIncome: number;
     householdSize: number;
   };


### PR DESCRIPTION
### 概要

世帯タイプのプリセット（独身/夫婦）から配偶者の有無が一意に決まるため、冗長な「配偶者あり」チェックボックスを削除し、`hasSpouse` をプリセットからの派生値に変更する。

### 背景

「配偶者あり」チェックボックスは設計書の入力仕様（`hasSpouse: boolean`）をもとに実装されたが、世帯タイプのプリセットボタン（独身/夫婦（片働き）/夫婦（共働き））が既に配偶者の有無を決定するため、チェックボックスとプリセットの状態が矛盾しうる設計上の問題があった。

### 変更内容

**`src/components/pension/PensionForm.tsx`**
- `hasSpouse` / `onHasSpouse` props を削除
- `startAgeMonths` / `onStartAgeMonths` / `slideFactorPercentLabel` の未使用 props を削除
- 「配偶者あり」チェックボックスを削除
- `hasSpouse` をコンポーネント内で `preset !== "single"` から導出するよう変更
- 配偶者年金・配偶者所得の表示切替は引き続き `hasSpouse` で制御

**`src/components/pension/PensionSimulator.tsx`**
- `hasSpouse` の `useState` 管理を廃止し、`preset !== "single"` の派生値に変更
- `applyPreset` 内の `setHasSpouse(f.hasSpouse)` 呼び出しを削除
- `PensionForm` への不要 props の受け渡しを削除

**`src/lib/calculations.ts`**
- `applyFamilyPreset` の戻り値型から `hasSpouse` を除外（`spouseIncome` / `householdSize` のみ返却）

**`年金シミュレーター.md`**
- 3.2 世帯情報の入力仕様から「配偶者の有無」行を削除
- `UserInput` 型の `hasSpouse` フィールドに、プリセットから導出される値である旨の注釈を追加

### 動作確認

- [x] `npm run dev` で開発サーバーが起動すること
- [x] `npm run build` でビルドエラーがないこと
- [x] 世帯タイプを「独身」に切り替えたとき、配偶者年金・配偶者所得の入力欄が非表示になること
- [x] 世帯タイプを「夫婦（片働き）」「夫婦（共働き）」に切り替えたとき、配偶者年金・配偶者所得の入力欄が表示されること