### PR TITLE
出力エリアの「最終月の手取り」を「月額手取り（100歳時点）」にリネームしグループ表示に変更

### DIFF
--- a/src/components/pension/PensionOutput.tsx
+++ b/src/components/pension/PensionOutput.tsx
@@ -24,13 +24,18 @@ export function PensionOutput({ breakevenLabel, takeAhead, last, last65 }: Pensi
                     <dt className="text-slate-600">繰上げ時の先取り累積差（65歳直前）</dt>
                     <dd className="text-right tabular-nums text-slate-900">{formatYen(takeAhead)}</dd>
                 </div>
-                <div className="flex justify-between gap-4 border-b border-slate-100 py-2">
-                    <dt className="text-slate-600">最終月の手取り（スライド開始）</dt>
-                    <dd className="text-right tabular-nums text-slate-900">{formatYen(last.net)}</dd>
-                </div>
-                <div className="flex justify-between gap-4 border-b border-slate-100 py-2">
-                    <dt className="text-slate-600">最終月の手取り（65歳開始）</dt>
-                    <dd className="text-right tabular-nums text-slate-900">{formatYen(last65.net)}</dd>
+                <div className="border-b border-slate-100 py-2">
+                    <dt className="text-slate-600">月額手取り（100歳時点）</dt>
+                    <div className="mt-1 space-y-1">
+                        <div className="flex justify-between gap-4">
+                            <span className="pl-3 text-xs text-slate-500">65歳開始</span>
+                            <dd className="text-right tabular-nums text-slate-900">{formatYen(last65.net)}</dd>
+                        </div>
+                        <div className="flex justify-between gap-4">
+                            <span className="pl-3 text-xs text-slate-500">スライド開始</span>
+                            <dd className="text-right tabular-nums text-slate-900">{formatYen(last.net)}</dd>
+                        </div>
+                    </div>
                 </div>
                 <div className="flex justify-between gap-4 border-b border-slate-100 py-2">
                     <dt className="text-slate-600">累積手取り（スライド・{AGE_END}歳手前）</dt>


### PR DESCRIPTION
### 概要

出力エリアの「最終月の手取り」という分かりにくい項目名を「月額手取り（100歳時点）」に改め、65歳開始・スライド開始の2値を共通ラベルの下にグループ表示する。

### 背景

「最終月の手取り」という表現は「最後の月に一度だけ受け取った金額」のような一時的な印象を与えており、実態（シミュレーション末時点＝100歳時点の月次手取り額）が伝わりにくかった。また、65歳開始とスライド開始が別々の行に並んでいたため、対比しにくい構造だった。

### 変更内容

**`src/components/pension/PensionOutput.tsx`**
- 「最終月の手取り（スライド開始）」「最終月の手取り（65歳開始）」の2行を削除
- 共通ラベル「月額手取り（100歳時点）」を1行にまとめ、その下に「65歳開始」「スライド開始」をインデントして並べるグループ表示に変更

### 動作確認

- [x] `npm run dev` で開発サーバーが起動すること
- [x] `npm run build` でビルドエラーがないこと
- [x] 出力エリアに「月額手取り（100歳時点）」が表示され、その下に「65歳開始」「スライド開始」の2行が字下げで表示されること