### PR TITLE
損益分岐の表示を2行に変更

### DIFF
--- a/src/components/pension/PensionOutput.tsx
+++ b/src/components/pension/PensionOutput.tsx
@@ -16,9 +16,9 @@ export function PensionOutput({ breakevenLabel, takeAhead, last, last65 }: Pensi
         <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
             <h2 className="mb-4 text-lg font-medium text-slate-800">出力</h2>
             <dl className="grid gap-3 text-sm">
-                <div className="flex justify-between gap-4 border-b border-slate-100 py-2">
+                <div className="border-b border-slate-100 py-2">
                     <dt className="text-slate-600">損益分岐（完全逆転）</dt>
-                    <dd className="text-right font-medium text-slate-900">{breakevenLabel}</dd>
+                    <dd className="mt-1 font-medium text-slate-900">{breakevenLabel}</dd>
                 </div>
                 <div className="flex justify-between gap-4 border-b border-slate-100 py-2">
                     <dt className="text-slate-600">繰上げ時の先取り累積差（65歳直前）</dt>


### PR DESCRIPTION
### 概要

出力エリアの「損益分岐（完全逆転）」の値を、ラベルと同じ行ではなく次の行に表示するよう変更した。
長い文言が1行に収まらず見づらかった問題を解消する。

### 背景

`breakevenLabel` は「○○歳○か月の時点で、累積手取りが65歳開始を下回ります。」のような長い文字列になるケースがある。
`flex justify-between` によってラベルと値を横並びにしていたため、文言が折り返されて非常に読みづらい状態だった。

### 変更内容

`src/components/pension/PensionOutput.tsx`

- `flex justify-between gap-4` を削除し、`dt` と `dd` を縦並びのブロックレイアウトに変更
- `dd` に `mt-1` を追加してラベルとの間隔を確保
- `dd` の `text-right` を削除し、左揃えで表示

```
変更前: [損益分岐（完全逆転）]  [長い説明文が折り返される...]
変更後: 損益分岐（完全逆転）
        長い説明文がすっきり1行に収まる
```

### 動作確認

- [x] `npm run dev` で開発サーバーを起動し、出力エリアの「損益分岐（完全逆転）」が2行表示になることを確認
- [x] 受給開始年齢を60〜75歳の範囲でスライドさせ、各ケース（繰上げ・65歳・繰下げ）で文言が正しく表示されることを確認
- [x] `npm run build` でビルドエラーがないことを確認