### PR TITLE
内訳カードの表示構造と題目を改善

### DIFF
--- a/src/components/pension/PensionBreakdown.tsx
+++ b/src/components/pension/PensionBreakdown.tsx
@@ -10,19 +10,23 @@ export type PensionBreakdownProps = {
 export function PensionBreakdown({ last }: PensionBreakdownProps) {
     return (
         <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-            <h3 className="mb-3 text-sm font-medium text-slate-800">内訳（最終月・スライド開始）</h3>
+            <h2 className="mb-4 text-lg font-medium text-slate-800">月額手取りの内訳（スライド開始・100歳時点）</h2>
             <ul className="space-y-2 text-sm text-slate-600">
                 <li className="flex justify-between">
-                    <span>税金（所得税＋住民税の合算・月額）</span>
-                    <span className="tabular-nums text-slate-900">{formatYen(last.tax)}</span>
-                </li>
-                <li className="flex justify-between">
-                    <span>社会保険料（健康保険＋介護・簡易・月額）</span>
-                    <span className="tabular-nums text-slate-900">{formatYen(last.insurance)}</span>
-                </li>
-                <li className="flex justify-between border-t border-slate-100 pt-2">
                     <span>支給額（月額・グロス）</span>
                     <span className="tabular-nums text-slate-900">{formatYen(last.gross)}</span>
+                </li>
+                <li className="flex justify-between pl-3">
+                    <span>− 税金（所得税＋住民税）</span>
+                    <span className="tabular-nums text-slate-900">{formatYen(last.tax)}</span>
+                </li>
+                <li className="flex justify-between pl-3">
+                    <span>− 社会保険料（健康保険＋介護）</span>
+                    <span className="tabular-nums text-slate-900">{formatYen(last.insurance)}</span>
+                </li>
+                <li className="flex justify-between border-t border-slate-100 pt-2 font-medium text-slate-800">
+                    <span>手取り（月額）</span>
+                    <span className="tabular-nums">{formatYen(last.net)}</span>
                 </li>
             </ul>
         </div>


### PR DESCRIPTION
### 概要

出力エリア下部の内訳カードについて、項目の並び順・表示内容・題目を見直した。
「支給額 → 控除項目 → 手取り」という引き算の流れで読めるUIに変更し、題目も内容を正確に反映した名称に改めた。

### 背景

変更前の内訳カードは以下の問題があった。

- 項目の順番が「税金 → 社会保険料 → 支給額（グロス）」と逆順で、引き算の構造が読み取れなかった
- 手取りが表示されておらず、グロスから何を引いた結果になるのかが不明だった
- 題目が「内訳（最終月・スライド開始）」と曖昧で、何の内訳かがわかりにくかった

### 変更内容

`src/components/pension/PensionBreakdown.tsx`

**題目の変更**
- 変更前: `内訳（最終月・スライド開始）`（`h3` / `text-sm`）
- 変更後: `月額手取りの内訳（スライド開始・100歳時点）`（`h2` / `text-lg`）
  - 他の出力カード（「出力」「累積手取りの推移」）と同じ見出しレベル・サイズに統一

**表示構造の変更**

```
変更前:
  税金（所得税＋住民税の合算・月額）   ¥〇〇
  社会保険料（健康保険＋介護・簡易・月額） ¥〇〇
  ────────────────────────────────
  支給額（月額・グロス）              ¥〇〇

変更後:
  支給額（月額・グロス）              ¥〇〇
    − 税金（所得税＋住民税）          ¥〇〇
    − 社会保険料（健康保険＋介護）    ¥〇〇
  ────────────────────────────────
  手取り（月額）                      ¥〇〇
```

- 控除項目を `pl-3` でインデントし「−」プレフィックスを付与
- 末尾に `last.net` を使った「手取り（月額）」行を追加し、`font-medium` で締めの行として強調

### 動作確認

- [x] `npm run dev` で開発サーバーを起動し、内訳カードが「支給額 → 控除 → 手取り」の順で表示されることを確認
- [x] 受給開始年齢をスライドさせ、各ケースで金額が正しく反映されることを確認
- [x] `npm run build` でビルドエラーがないことを確認
