### PR TITLE
損益分岐をグラフ上に表示する

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11,3 +11,8 @@ body {
     color: var(--foreground);
     background: var(--background);
 }
+
+@keyframes breakeven-fadein {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}

--- a/src/components/pension/PensionChartInner.tsx
+++ b/src/components/pension/PensionChartInner.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CartesianGrid, Legend, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { CartesianGrid, Legend, Line, LineChart, ReferenceDot, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import { formatYen, formatYenGroupedDigits } from "@/lib/format-yen";
 import { AGE_END, AGE_START } from "./pension-defaults";
 
@@ -14,9 +14,76 @@ export type PensionChartInnerProps = {
     chartData: ChartRow[];
     startAgeYears: number;
     startAgeMonths: number;
+    breakevenAgeYears: number | null;
+    breakevenCumulative: number | null;
+    showBreakeven: boolean;
 };
 
-export function PensionChartInner({ chartData, startAgeYears, startAgeMonths }: PensionChartInnerProps) {
+type CalloutProps = {
+    // recharts が ReferenceDot の label に渡す viewBox は { x: cx-r, y: cy-r, width: 2r, height: 2r }
+    viewBox?: { x: number; y: number; width: number; height: number };
+    text: string;
+    flip: boolean;
+};
+
+/** 損益分岐点の吹き出しラベル（SVG） */
+function BreakevenCallout({ viewBox, text, flip }: CalloutProps) {
+    if (!viewBox) return null;
+    // ドット中心座標を復元
+    const cx = viewBox.x + viewBox.width / 2;
+    const cy = viewBox.y + viewBox.height / 2;
+    const bw = 104;
+    const bh = 26;
+    // 吹き出しの角（ドットと接するコーナー）をドット中心から少しずらす
+    const offsetX = 8;
+    const offsetY = 10;
+
+    if (flip) {
+        // 右半分：吹き出しをドットの左上に配置（底右コーナーがドット近傍）
+        const cornerX = cx - offsetX;
+        const cornerY = cy - offsetY;
+        const bx = cornerX - bw;
+        const by = cornerY - bh;
+        return (
+            <g style={{ animation: "breakeven-fadein 0.5s ease-out forwards" }}>
+                {/* ドットから吹き出しコーナーへの三角テール */}
+                <polygon points={`${cx},${cy} ${cornerX - 10},${cornerY} ${cornerX},${cornerY}`} fill="#dc2626" />
+                <rect x={bx} y={by} width={bw} height={bh} rx={5} fill="#dc2626" />
+                <text x={bx + bw / 2} y={by + bh / 2 + 4} textAnchor="middle" fill="white" fontSize={11} fontWeight="600" fontFamily="sans-serif">
+                    {text}
+                </text>
+            </g>
+        );
+    }
+
+    // 左半分：吹き出しをドットの右上に配置（底左コーナーがドット近傍）
+    const cornerX = cx + offsetX;
+    const cornerY = cy - offsetY;
+    const bx = cornerX;
+    const by = cornerY - bh;
+    return (
+        <g style={{ animation: "breakeven-fadein 0.5s ease-out forwards" }}>
+            {/* ドットから吹き出しコーナーへの三角テール */}
+            <polygon points={`${cx},${cy} ${cornerX},${cornerY} ${cornerX + 10},${cornerY}`} fill="#dc2626" />
+            <rect x={bx} y={by} width={bw} height={bh} rx={5} fill="#dc2626" />
+            <text x={bx + bw / 2} y={by + bh / 2 + 4} textAnchor="middle" fill="white" fontSize={11} fontWeight="600" fontFamily="sans-serif">
+                {text}
+            </text>
+        </g>
+    );
+}
+
+export function PensionChartInner({ chartData, startAgeYears, startAgeMonths, breakevenAgeYears, breakevenCumulative, showBreakeven }: PensionChartInnerProps) {
+    const breakevenText = (() => {
+        if (breakevenAgeYears === null) return null;
+        const years = Math.floor(breakevenAgeYears);
+        const months = Math.round((breakevenAgeYears - years) * 12);
+        return `${years}歳${months > 0 ? `${months}か月` : ""}`;
+    })();
+
+    const midAge = (AGE_START + AGE_END) / 2;
+    const flip = breakevenAgeYears !== null && breakevenAgeYears > midAge;
+
     return (
         <ResponsiveContainer
             width="100%"
@@ -64,6 +131,18 @@ export function PensionChartInner({ chartData, startAgeYears, startAgeMonths }: 
                     strokeWidth={2}
                     dot={false}
                 />
+                {showBreakeven && breakevenAgeYears !== null && breakevenCumulative !== null && breakevenText !== null && (
+                    <ReferenceDot
+                        x={breakevenAgeYears}
+                        y={breakevenCumulative}
+                        r={5}
+                        fill="#dc2626"
+                        stroke="white"
+                        strokeWidth={2}
+                        isFront={true}
+                        label={<BreakevenCallout text={breakevenText} flip={flip} />}
+                    />
+                )}
             </LineChart>
         </ResponsiveContainer>
     );

--- a/src/components/pension/PensionSimulator.tsx
+++ b/src/components/pension/PensionSimulator.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { AGE_END, AGE_START, annualAt65FromInput, applyFamilyPreset, buildChartRows, earlyTakeAheadAmount, findBreakdownMonth, findBreakevenMonth, pensionAnnualFactor, runScenario, type FamilyPreset, type UserInput } from "@/lib/calculations";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { PensionBreakdown } from "./PensionBreakdown";
 import { PensionChart } from "./PensionChart";
 import { PensionDisclaimers } from "./PensionDisclaimers";
@@ -21,6 +21,18 @@ export function PensionSimulator() {
     const [lifeInsurance, setLifeInsurance] = useState(defaultPensionInput.insurance.lifeInsurance);
     const [medicalExpense, setMedicalExpense] = useState(defaultPensionInput.insurance.medicalExpense);
     const [startAgeMonths, setStartAgeMonths] = useState(65 * 12);
+    const [showBreakeven, setShowBreakeven] = useState(false);
+    const breakevenTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    // スライダー操作中は即座に非表示、停止後 1200ms でフェードイン表示
+    useEffect(() => {
+        setShowBreakeven(false);
+        if (breakevenTimerRef.current) clearTimeout(breakevenTimerRef.current);
+        breakevenTimerRef.current = setTimeout(() => setShowBreakeven(true), 1200);
+        return () => {
+            if (breakevenTimerRef.current) clearTimeout(breakevenTimerRef.current);
+        };
+    }, [startAgeMonths]);
 
     const startAgeYears = startAgeMonths / 12;
 
@@ -60,22 +72,26 @@ export function PensionSimulator() {
         setHouseholdSize(f.householdSize);
     };
 
+    const breakevenIdx = useMemo(() => {
+        if (startAgeYears === 65) return null;
+        if (startAgeYears < 65) return findBreakdownMonth(cumSlide, cum65);
+        return findBreakevenMonth(cumSlide, cum65);
+    }, [startAgeYears, cumSlide, cum65]);
+
+    const breakevenAgeYears = breakevenIdx !== null ? AGE_START + breakevenIdx / 12 : null;
+    const breakevenCumulative =
+        breakevenIdx !== null
+            ? ((resultsSlide[breakevenIdx]?.cumulativeNet ?? 0) + (results65[breakevenIdx]?.cumulativeNet ?? 0)) / 2
+            : null;
+
     const breakevenLabel = (() => {
         if (startAgeYears === 65) {
             return `65歳開始と同条件のため、常に累積手取りは同等です。`;
         }
 
-        let currentBreakevenIdx: number | null;
-        let isLookingForBreakdown = false;
+        const isLookingForBreakdown = startAgeYears < 65;
 
-        if (startAgeYears < 65) {
-            currentBreakevenIdx = findBreakdownMonth(cumSlide, cum65);
-            isLookingForBreakdown = true;
-        } else {
-            currentBreakevenIdx = findBreakevenMonth(cumSlide, cum65);
-        }
-
-        if (currentBreakevenIdx === null) {
+        if (breakevenIdx === null) {
             if (isLookingForBreakdown) {
                 return `シミュレーション終了時点（${AGE_END}歳）まで、常に累積手取りは65歳開始を上回っています。`;
             } else {
@@ -83,9 +99,8 @@ export function PensionSimulator() {
             }
         }
 
-        const ageDec = AGE_START + currentBreakevenIdx / 12;
-        const years = Math.floor(ageDec);
-        const months = Math.round((ageDec - years) * 12);
+        const years = Math.floor(breakevenAgeYears!);
+        const months = Math.round((breakevenAgeYears! - years) * 12);
         const ageString = `${years}歳${months > 0 ? `${months}か月` : ""}`;
 
         if (isLookingForBreakdown) {
@@ -124,6 +139,9 @@ export function PensionSimulator() {
                         chartData={chartData}
                         startAgeYears={startAgeYears}
                         startAgeMonths={startAgeMonths}
+                        breakevenAgeYears={breakevenAgeYears}
+                        breakevenCumulative={breakevenCumulative}
+                        showBreakeven={showBreakeven}
                     />
                 </div>
             </section>


### PR DESCRIPTION
### 概要

損益分岐点の年齢をグラフ上に吹き出しで表示する機能を追加した。スライダー操作中は非表示とし、操作停止後にフェードインで表示する。

### 背景

テキストエリアの「損益分岐（完全逆転）」欄に表示されていた年齢情報（例：「83歳6か月の時点で...」）をグラフ上でも視覚的に確認できるようにするため。

### 変更内容

- **`src/components/pension/PensionChartInner.tsx`**
  - `ReferenceDot` を用いて損益分岐点にドットを描画
  - カスタム SVG コンポーネント `BreakevenCallout` で吹き出しラベルを表示
  - 吹き出しの左右配置は損益分岐点がグラフ中央（80歳）より右側かどうかで切り替え（`flip` フラグ）
  - recharts が `ReferenceDot` のラベルに渡す `viewBox` は `{ x: cx-r, y: cy-r, width: 2r, height: 2r }` 形式であるため、そこからドット中心座標を復元して配置を計算
  - 新 props: `breakevenAgeYears`, `breakevenCumulative`, `showBreakeven`

- **`src/components/pension/PensionSimulator.tsx`**
  - `breakevenIdx` を `useMemo` で一元管理し、`breakevenLabel`（テキスト表示）と `breakevenAgeYears` / `breakevenCumulative`（グラフ表示）の両方で共用
  - `showBreakeven` state と `useEffect` + `useRef` によるデバウンス処理を追加（スライダー変更時に即非表示 → 1200ms 後にフェードイン）

- **`src/app/globals.css`**
  - 吹き出しフェードイン用の `@keyframes breakeven-fadein` を追加

### 動作確認

- [x] `npm run build` でエラーなし
- [x] 65歳より早い開始：損益分岐点（下回るタイミング）が吹き出しで表示される
- [x] 65歳より遅い開始：損益分岐点（上回るタイミング）が吹き出しで表示される
- [x] 65歳開始：吹き出しは非表示
- [x] スライダー操作中は吹き出しが非表示になり、停止後にフェードインで再表示される
- [x] 損益分岐点がグラフ右半分の場合は吹き出しが左上、左半分の場合は右上に配置される
