### PR TITLE
損益分岐点グラフのツールチップを月次刻みに変更する

### DIFF
--- a/src/components/pension/PensionChartInner.tsx
+++ b/src/components/pension/PensionChartInner.tsx
@@ -112,7 +112,11 @@ export function PensionChartInner({ chartData, startAgeYears, startAgeMonths, br
                 />
                 <Tooltip
                     formatter={(value: number) => formatYen(value)}
-                    labelFormatter={(age) => `${age}歳時点（年次サンプル）`}
+                    labelFormatter={(age: number) => {
+                        const years = Math.floor(age);
+                        const months = Math.round((age - years) * 12);
+                        return months > 0 ? `${years}歳${months}か月時点` : `${years}歳時点`;
+                    }}
                 />
                 <Legend wrapperStyle={{ paddingTop: 20 }} />
                 <Line

--- a/src/lib/calculations.ts
+++ b/src/lib/calculations.ts
@@ -241,15 +241,17 @@ export function earlyTakeAheadAmount(results65: MonthlyResult[], resultsSlide: M
 
 export function buildChartRows(results65: MonthlyResult[], resultsSlide: MonthlyResult[]): { age: number; cumulative65: number; cumulativeSlide: number }[] {
     const rows: { age: number; cumulative65: number; cumulativeSlide: number }[] = [];
-    for (let i = 0; i < results65.length; i += 12) {
+    for (let i = 0; i < results65.length; i++) {
         const r65 = results65[i]!;
         const rs = resultsSlide[i]!;
         rows.push({
-            age: Math.floor(AGE_START + i / 12),
+            // 小数で月を表現（例: 65.0833... = 65歳1か月）
+            age: AGE_START + i / 12,
             cumulative65: r65.cumulativeNet,
             cumulativeSlide: rs.cumulativeNet,
         });
     }
+    // 末尾補完は月次では不要（全月分が揃っている）
     const last = MONTHS - 1;
     const r65l = results65[last]!;
     const rsll = resultsSlide[last]!;


### PR DESCRIPTION
### 概要

グラフのツールチップを年次サンプルから月次に変更し、マウスオーバー時に1か月刻みで累積手取り額を確認できるようにした。

### 背景

変更前はチャートデータが1年ごとにサンプリングされており、グラフ上でカーソルを動かしても1歳刻みでしか案内が表示されなかった。月単位でシミュレーションしているデータをそのままグラフに反映し、より細かい確認ができるようにするため。

### 変更内容

- **`src/lib/calculations.ts`**
  - `buildChartRows` のループを `i += 12`（年次）から `i++`（月次）に変更
  - `age` フィールドを `Math.floor` の整数から小数値（例：`65.083...` = 65歳1か月）に変更

- **`src/components/pension/PensionChartInner.tsx`**
  - `Tooltip` の `labelFormatter` を更新：小数の age を「○歳○か月時点」形式に変換
  - 整数か月（0か月）の場合は「○歳時点」と表示（例：66歳0か月 → 「66歳時点」）

### 動作確認

- [x] `npm run build` でエラーなし
- [x] グラフ上でカーソルを動かすと1か月刻みでツールチップが追従する
- [x] ツールチップのラベルが「○歳○か月時点」形式で表示される
- [x] 整数歳の時点では「○歳時点」と表示される