### PR TITLE
累積手取りの表示形式を月額手取りと同じレイアウトに統一する

### DIFF
--- a/src/components/pension/PensionOutput.tsx
+++ b/src/components/pension/PensionOutput.tsx
@@ -37,13 +37,18 @@ export function PensionOutput({ breakevenLabel, takeAhead, last, last65 }: Pensi
                         </div>
                     </div>
                 </div>
-                <div className="flex justify-between gap-4 border-b border-slate-100 py-2">
-                    <dt className="text-slate-600">累積手取り（スライド・{AGE_END}歳手前）</dt>
-                    <dd className="text-right tabular-nums text-slate-900">{formatYen(last.cumulativeNet)}</dd>
-                </div>
-                <div className="flex justify-between gap-4 py-2">
-                    <dt className="text-slate-600">累積手取り（65歳開始）</dt>
-                    <dd className="text-right tabular-nums text-slate-900">{formatYen(last65.cumulativeNet)}</dd>
+                <div className="py-2">
+                    <dt className="text-slate-600">累積手取り（{AGE_END}歳手前）</dt>
+                    <div className="mt-1 space-y-1">
+                        <div className="flex justify-between gap-4">
+                            <span className="pl-3 text-xs text-slate-500">65歳開始</span>
+                            <dd className="text-right tabular-nums text-slate-900">{formatYen(last65.cumulativeNet)}</dd>
+                        </div>
+                        <div className="flex justify-between gap-4">
+                            <span className="pl-3 text-xs text-slate-500">スライド開始</span>
+                            <dd className="text-right tabular-nums text-slate-900">{formatYen(last.cumulativeNet)}</dd>
+                        </div>
+                    </div>
                 </div>
             </dl>
         </div>


### PR DESCRIPTION
### 概要

出力カードの「累積手取り」表示を「月額手取り（100歳時点）」と同じブロック形式に統一した。

### 背景

変更前は累積手取りが「スライド開始」と「65歳開始」で別々の行として並列表示されていたため、月額手取りの表示形式（見出し＋2行のサブ項目）と統一感がなかった。

### 変更内容

- **`src/components/pension/PensionOutput.tsx`**
  - 「累積手取り（スライド・{AGE_END}歳手前）」と「累積手取り（65歳開始）」の2つの独立した行を1つのブロックに統合
  - 見出し「累積手取り（{AGE_END}歳手前）」の下に「65歳開始」「スライド開始」をサブ項目として並べる形式に変更
  - 月額手取りと同様に `pl-3 text-xs text-slate-500` でサブラベルをインデント表示

### 動作確認

- [x] `npm run build` でエラーなし
- [x] 出力カードの累積手取りが「月額手取り（100歳時点）」と同じレイアウトで表示される
- [x] 65歳開始・スライド開始それぞれの累積手取り額が正しく表示される