### PR TITLE
繰上げ時の先取り累積差の条件表示と AGE_STANDARD 定数化

### DIFF
--- a/src/components/pension/PensionOutput.tsx
+++ b/src/components/pension/PensionOutput.tsx
@@ -1,17 +1,18 @@
 "use client";
 
 import { formatYen } from "@/lib/format-yen";
-import type { MonthlyResult } from "@/lib/calculations";
+import { AGE_STANDARD, type MonthlyResult } from "@/lib/calculations";
 import { AGE_END } from "./pension-defaults";
 
 export type PensionOutputProps = {
     breakevenLabel: string;
     takeAhead: number;
+    startAgeYears: number;
     last: MonthlyResult;
     last65: MonthlyResult;
 };
 
-export function PensionOutput({ breakevenLabel, takeAhead, last, last65 }: PensionOutputProps) {
+export function PensionOutput({ breakevenLabel, takeAhead, startAgeYears, last, last65 }: PensionOutputProps) {
     return (
         <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
             <h2 className="mb-4 text-lg font-medium text-slate-800">出力</h2>
@@ -20,10 +21,12 @@ export function PensionOutput({ breakevenLabel, takeAhead, last, last65 }: Pensi
                     <dt className="text-slate-600">損益分岐（完全逆転）</dt>
                     <dd className="mt-1 font-medium text-slate-900">{breakevenLabel}</dd>
                 </div>
-                <div className="flex justify-between gap-4 border-b border-slate-100 py-2">
-                    <dt className="text-slate-600">繰上げ時の先取り累積差（65歳直前）</dt>
-                    <dd className="text-right tabular-nums text-slate-900">{formatYen(takeAhead)}</dd>
-                </div>
+                {startAgeYears < AGE_STANDARD && (
+                    <div className="flex justify-between gap-4 border-b border-slate-100 py-2">
+                        <dt className="text-slate-600">繰上げ時の先取り累積差（65歳直前）</dt>
+                        <dd className="text-right tabular-nums text-slate-900">{formatYen(takeAhead)}</dd>
+                    </div>
+                )}
                 <div className="border-b border-slate-100 py-2">
                     <dt className="text-slate-600">月額手取り（100歳時点）</dt>
                     <div className="mt-1 space-y-1">

--- a/src/components/pension/PensionSimulator.tsx
+++ b/src/components/pension/PensionSimulator.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AGE_END, AGE_START, annualAt65FromInput, applyFamilyPreset, buildChartRows, earlyTakeAheadAmount, findBreakdownMonth, findBreakevenMonth, pensionAnnualFactor, runScenario, type FamilyPreset, type UserInput } from "@/lib/calculations";
+import { AGE_END, AGE_STANDARD, AGE_START, annualAt65FromInput, applyFamilyPreset, buildChartRows, earlyTakeAheadAmount, findBreakdownMonth, findBreakevenMonth, pensionAnnualFactor, runScenario, type FamilyPreset, type UserInput } from "@/lib/calculations";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { PensionBreakdown } from "./PensionBreakdown";
 import { PensionChart } from "./PensionChart";
@@ -20,7 +20,7 @@ export function PensionSimulator() {
     const [householdSize, setHouseholdSize] = useState(defaultPensionInput.family.householdSize);
     const [lifeInsurance, setLifeInsurance] = useState(defaultPensionInput.insurance.lifeInsurance);
     const [medicalExpense, setMedicalExpense] = useState(defaultPensionInput.insurance.medicalExpense);
-    const [startAgeMonths, setStartAgeMonths] = useState(65 * 12);
+    const [startAgeMonths, setStartAgeMonths] = useState(AGE_STANDARD * 12);
     const [showBreakeven, setShowBreakeven] = useState(false);
     const breakevenTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -51,7 +51,7 @@ export function PensionSimulator() {
     );
 
     const annual65 = useMemo(() => annualAt65FromInput(input), [input]);
-    const results65 = useMemo(() => runScenario(input, 65, annual65), [input, annual65]);
+    const results65 = useMemo(() => runScenario(input, AGE_STANDARD, annual65), [input, annual65]);
     const resultsSlide = useMemo(() => runScenario(input, startAgeYears, annual65), [input, startAgeYears, annual65]);
 
     const chartData = useMemo(() => buildChartRows(results65, resultsSlide), [results65, resultsSlide]);
@@ -73,8 +73,8 @@ export function PensionSimulator() {
     };
 
     const breakevenIdx = useMemo(() => {
-        if (startAgeYears === 65) return null;
-        if (startAgeYears < 65) return findBreakdownMonth(cumSlide, cum65);
+        if (startAgeYears === AGE_STANDARD) return null;
+        if (startAgeYears < AGE_STANDARD) return findBreakdownMonth(cumSlide, cum65);
         return findBreakevenMonth(cumSlide, cum65);
     }, [startAgeYears, cumSlide, cum65]);
 
@@ -85,11 +85,11 @@ export function PensionSimulator() {
             : null;
 
     const breakevenLabel = (() => {
-        if (startAgeYears === 65) {
+        if (startAgeYears === AGE_STANDARD) {
             return `65歳開始と同条件のため、常に累積手取りは同等です。`;
         }
 
-        const isLookingForBreakdown = startAgeYears < 65;
+        const isLookingForBreakdown = startAgeYears < AGE_STANDARD;
 
         if (breakevenIdx === null) {
             if (isLookingForBreakdown) {
@@ -170,6 +170,7 @@ export function PensionSimulator() {
                     <PensionOutput
                         breakevenLabel={breakevenLabel}
                         takeAhead={takeAhead}
+                        startAgeYears={startAgeYears}
                         last={last}
                         last65={last65}
                     />

--- a/src/components/pension/pension-defaults.ts
+++ b/src/components/pension/pension-defaults.ts
@@ -1,11 +1,9 @@
-import type { UserInput } from "@/lib/calculations";
-
-export const AGE_START = 60;
-export const AGE_END = 100;
+export { AGE_END, AGE_STANDARD, AGE_START } from "@/lib/calculations";
+import { AGE_STANDARD, type UserInput } from "@/lib/calculations";
 
 export const defaultPensionInput: UserInput = {
     pension: { basic: 800_000, employee: 1_200_000, spousePension: 0 },
     family: { hasSpouse: false, spouseIncome: 0, householdSize: 1 },
     insurance: { lifeInsurance: 0, medicalExpense: 0 },
-    startAgeYears: 65,
+    startAgeYears: AGE_STANDARD,
 };

--- a/src/lib/calculations.ts
+++ b/src/lib/calculations.ts
@@ -33,8 +33,8 @@ export type MonthlyResult = {
 
 export const AGE_START = 60;
 export const AGE_END = 100;
+export const AGE_STANDARD = 65; // 標準受給開始年齢
 const MONTHS = (AGE_END - AGE_START) * 12;
-const REF_AGE = 65;
 const EARLY_RATE = 0.004;
 const LATE_RATE = 0.007;
 
@@ -57,7 +57,7 @@ function monthsFrom60ToAgeYears(ageYears: number): number {
 
 /** 65歳満額を基準とした年額係数 */
 export function pensionAnnualFactor(startAgeYears: number): number {
-    const monthsEarly = Math.round((REF_AGE - startAgeYears) * 12);
+    const monthsEarly = Math.round((AGE_STANDARD - startAgeYears) * 12);
     if (monthsEarly > 0) {
         return 1 - EARLY_RATE * monthsEarly;
     }
@@ -109,7 +109,7 @@ function spouseDeductionAmount(spouseIncome: number): number {
 }
 
 function nursingInsuranceRate(ageYears: number): number {
-    if (ageYears < 65) return 0;
+    if (ageYears < AGE_STANDARD) return 0;
     if (ageYears < 75) return 0.018;
     return 0.024;
 }
@@ -234,7 +234,7 @@ export function annualAt65FromInput(input: UserInput): number {
 
 /** 繰上げ等で65歳到達直前（65歳開始がまだ0円のとき）の先取り累積差 */
 export function earlyTakeAheadAmount(results65: MonthlyResult[], resultsSlide: MonthlyResult[]): number {
-    const idx = monthsFrom60ToAgeYears(REF_AGE) - 1;
+    const idx = monthsFrom60ToAgeYears(AGE_STANDARD) - 1;
     if (idx < 0) return 0;
     return resultsSlide[idx]!.cumulativeNet - results65[idx]!.cumulativeNet;
 }


### PR DESCRIPTION
### 概要

「繰上げ時の先取り累積差」を65歳より前の設定時のみ表示するよう変更し、あわせて各所に散在していたマジックナンバー `65` を定数 `AGE_STANDARD` に置換した。

### 背景

- 「繰上げ時の先取り累積差（65歳直前）」は繰上げ受給時にしか意味を持たない項目だが、65歳以降の設定でも常に表示されていた
- `65` というリテラルが複数ファイルに点在しており、標準受給開始年齢の意図が読み取りにくかった

### 変更内容

- **`src/lib/calculations.ts`**
  - `export const AGE_STANDARD = 65` を追加
  - 不要な中間変数 `REF_AGE = AGE_STANDARD` を削除し、直接 `AGE_STANDARD` を参照するように変更
  - `nursingInsuranceRate` 内のリテラル `65` を `AGE_STANDARD` に置換

- **`src/components/pension/pension-defaults.ts`**
  - `AGE_START`・`AGE_END` の独自定義を削除し、`calculations.ts` からの re-export に変更（重複解消）
  - `startAgeYears: 65` を `AGE_STANDARD` に置換

- **`src/components/pension/PensionSimulator.tsx`**
  - `useState(65 * 12)` → `useState(AGE_STANDARD * 12)`
  - `runScenario(input, 65, ...)` → `runScenario(input, AGE_STANDARD, ...)`
  - `startAgeYears === 65` / `startAgeYears < 65` の比較を `AGE_STANDARD` に置換

- **`src/components/pension/PensionOutput.tsx`**
  - `startAgeYears < AGE_STANDARD` の場合のみ「繰上げ時の先取り累積差（65歳直前）」を表示
  - `startAgeYears` を新 prop として追加

### 動作確認

- [x] `npm run build` でエラーなし
- [x] 受給開始を65歳未満に設定すると「繰上げ時の先取り累積差」が表示される
- [x] 受給開始を65歳以上に設定すると同項目が非表示になる