### PR TITLE
グラフの末端に生じたバグの修正

### DIFF
--- a/src/components/pension/PensionChartInner.tsx
+++ b/src/components/pension/PensionChartInner.tsx
@@ -100,7 +100,7 @@ export function PensionChartInner({ chartData, startAgeYears, startAgeMonths, br
                 <XAxis
                     dataKey="age"
                     type="number"
-                    domain={[AGE_START, AGE_END - 1]}
+                    domain={[AGE_START, AGE_END]}
                     tick={{ fontSize: 12 }}
                     label={{ value: "年齢（歳）", position: "insideBottom", offset: -4 }}
                 />

--- a/src/lib/calculations.ts
+++ b/src/lib/calculations.ts
@@ -304,24 +304,15 @@ export function buildChartRows(results65: MonthlyResult[], resultsSlide: Monthly
             cumulativeSlide: rs.cumulativeNet,
         });
     }
-    // 末尾補完は月次では不要（全月分が揃っている）
+    // 最終行の age を AGE_END（100）に補正して軸目盛りと合わせる
     const last = MONTHS - 1;
     const r65l = results65[last]!;
     const rsll = resultsSlide[last]!;
-    const lastAgeFloor = Math.floor(AGE_START + last / 12);
-    if (rows[rows.length - 1]?.age !== lastAgeFloor) {
-        rows.push({
-            age: lastAgeFloor,
-            cumulative65: r65l.cumulativeNet,
-            cumulativeSlide: rsll.cumulativeNet,
-        });
-    } else {
-        rows[rows.length - 1] = {
-            age: lastAgeFloor,
-            cumulative65: r65l.cumulativeNet,
-            cumulativeSlide: rsll.cumulativeNet,
-        };
-    }
+    rows[rows.length - 1] = {
+        age: AGE_END,
+        cumulative65: r65l.cumulativeNet,
+        cumulativeSlide: rsll.cumulativeNet,
+    };
     return rows;
 }
 


### PR DESCRIPTION
### 概要

グラフのX軸末端に `99.9166...` という小数値の目盛りが表示されていたバグを修正した。軸の末端が `100` として表示されるようになる。

### 背景

月次グラフ対応（前PR）でチャートデータを月単位（480件）に変更した際、最終データ点の `age` が `60 + 479/12 = 99.9166...` となっていた。また末尾補完ロジックが年次時代の名残で正しく動作しておらず、`99.9166...` の行を残したまま `age=99` の行を追加するという不正な状態になっていた。さらに `XAxis` の `domain` 上限が `AGE_END - 1 = 99` だったため、rechartsが `99.9166...` のデータ点をスケールに含めて表示していた。

### 変更内容

- **`src/lib/calculations.ts`**
  - `buildChartRows` の末尾補完ロジックを整理し、最終行の `age` を `AGE_END`（100）に上書きする処理に一本化
  - 年次時代の `if/else push` 分岐を削除

- **`src/components/pension/PensionChartInner.tsx`**
  - `XAxis` の `domain` を `[AGE_START, AGE_END - 1]` から `[AGE_START, AGE_END]` に変更

### 動作確認

- [x] `npm run build` でエラーなし
- [x] グラフのX軸末端が `100` と表示される