### PR TITLE
縦軸の最大値固定を解除し入力値に応じた動的スケールに戻す

### DIFF
--- a/src/components/pension/PensionChartInner.tsx
+++ b/src/components/pension/PensionChartInner.tsx
@@ -109,7 +109,6 @@ export function PensionChartInner({ chartData, startAgeYears, startAgeMonths, br
                     tick={{ fontSize: 11 }}
                     width={92}
                     tickMargin={8}
-                    domain={[0, 80_000_000]}
                 />
                 <Tooltip
                     formatter={(value: number) => formatYen(value)}


### PR DESCRIPTION
### 概要

グラフの縦軸最大値の固定（8,000万円）を解除し、入力値に応じて自動スケールされるよう変更した。

### 背景

年金額や家族構成の入力値によっては累積手取りが8,000万円を大きく上回る・下回るケースがあり、固定値ではグラフが潰れたり余白が広くなりすぎる問題があった。

### 変更内容

- **`src/components/pension/PensionChartInner.tsx`**
  - `YAxis` の `domain={[0, 80_000_000]}` を削除し、rechartsのオートスケールに戻す

### 動作確認

- [x] `npm run build` でエラーなし
- [x] 入力値を変えると縦軸が適切なスケールで自動調整される