### PR TITLE
損益分岐点の全受給開始年齢一覧ページを追加

### DIFF
--- a/src/app/breakeven/page.tsx
+++ b/src/app/breakeven/page.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { annualAt65FromInput, computeAllBreakevens, type BreakevenPoint } from "@/lib/calculations";
+import { usePensionInput } from "@/lib/pension-input-context";
+
+const BreakevenAllChart = dynamic(
+    () => import("@/components/pension/BreakevenAllChart").then((m) => m.BreakevenAllChart),
+    { ssr: false },
+);
+
+export default function BreakevenPage() {
+    const { preset, basic, employee, spousePension, spouseIncome, householdSize, lifeInsurance, medicalExpense } =
+        usePensionInput();
+    const hasSpouse = preset !== "single";
+
+    const [data, setData] = useState<BreakevenPoint[] | null>(null);
+
+    useEffect(() => {
+        const input = {
+            pension: { basic, employee, spousePension: hasSpouse ? spousePension : 0 },
+            family: { hasSpouse, spouseIncome, householdSize },
+            insurance: { lifeInsurance, medicalExpense },
+        };
+        const annual65 = annualAt65FromInput({ ...input, startAgeYears: 65 });
+        const points = computeAllBreakevens(input, annual65);
+        setData(points);
+    }, [basic, employee, spousePension, hasSpouse, spouseIncome, householdSize, lifeInsurance, medicalExpense]);
+
+    return (
+        <div className="mx-auto max-w-5xl px-4 py-10 space-y-8">
+            <div className="flex items-center gap-3">
+                <Link href="/" className="text-sm text-slate-500 hover:text-slate-700">
+                    ← シミュレーターに戻る
+                </Link>
+            </div>
+
+            <div>
+                <h1 className="text-xl font-semibold text-slate-800">損益分岐点 — 全受給開始年齢</h1>
+                <p className="mt-1 text-sm text-slate-500">
+                    受給開始年齢ごとに、累積手取りが65歳開始を上回る（または下回る）年齢を表示します。
+                </p>
+            </div>
+
+            <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+                {data === null ? (
+                    <div className="flex h-[420px] items-center justify-center">
+                        <div className="h-8 w-8 animate-spin rounded-full border-4 border-slate-200 border-t-slate-700" />
+                    </div>
+                ) : (
+                    <BreakevenAllChart data={data} />
+                )}
+            </div>
+
+            <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 text-xs text-slate-500 space-y-1">
+                <p className="font-medium text-slate-600">現在の入力値</p>
+                <p>基礎年金: {basic.toLocaleString()}円 / 厚生年金: {employee.toLocaleString()}円</p>
+                {hasSpouse && <p>配偶者年金: {spousePension.toLocaleString()}円 / 配偶者所得: {spouseIncome.toLocaleString()}円</p>}
+                <p>世帯人数: {householdSize}人</p>
+            </div>
+        </div>
+    );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import { PensionInputProvider } from "@/lib/pension-input-context";
 
 export const metadata: Metadata = {
     title: "年金繰上げ・繰下げシミュレーター",
@@ -13,7 +14,9 @@ export default function RootLayout({
 }>) {
     return (
         <html lang="ja">
-            <body className="min-h-screen antialiased">{children}</body>
+            <body className="min-h-screen antialiased">
+                <PensionInputProvider>{children}</PensionInputProvider>
+            </body>
         </html>
     );
 }

--- a/src/components/pension/BreakevenAllChart.tsx
+++ b/src/components/pension/BreakevenAllChart.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { type BreakevenPoint } from "@/lib/calculations";
+import {
+    CartesianGrid,
+    ReferenceLine,
+    ResponsiveContainer,
+    Scatter,
+    ScatterChart,
+    Tooltip,
+    XAxis,
+    YAxis,
+} from "recharts";
+
+type Props = {
+    data: BreakevenPoint[];
+};
+
+function formatAge(ageYears: number): string {
+    const years = Math.floor(ageYears);
+    const months = Math.round((ageYears - years) * 12);
+    return months > 0 ? `${years}歳${months}か月` : `${years}歳`;
+}
+
+export function BreakevenAllChart({ data }: Props) {
+    const plotData = data
+        .filter((p) => p.breakevenAgeYears !== null)
+        .map((p) => ({ x: p.startAgeYears, y: p.breakevenAgeYears as number }));
+
+    const hiddenCount = data.filter((p) => p.breakevenAgeYears === null).length;
+
+    return (
+        <div className="space-y-3">
+            <div className="h-[420px] w-full min-w-0">
+                <ResponsiveContainer width="100%" height="100%">
+                    <ScatterChart margin={{ top: 16, right: 24, bottom: 36, left: 16 }}>
+                        <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+                        <XAxis
+                            type="number"
+                            dataKey="x"
+                            domain={[60, 75]}
+                            ticks={[60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75]}
+                            tickFormatter={(v) => `${v}歳`}
+                            label={{ value: "受給開始年齢", position: "insideBottom", offset: -15, fontSize: 12, fill: "#64748b" }}
+                        />
+                        <YAxis
+                            type="number"
+                            dataKey="y"
+                            domain={[75, 95]}
+                            ticks={[75, 80, 85, 90, 95]}
+                            tickFormatter={(v) => `${v}歳`}
+                            label={{ value: "損益分岐年齢", angle: -90, position: "insideLeft", offset: -4, dx: -1, fontSize: 12, fill: "#64748b" }}
+                            width={60}
+                        />
+                        <Tooltip
+                            content={({ payload }) => {
+                                if (!payload?.length) return null;
+                                const d = payload[0]?.payload as { x: number; y: number } | undefined;
+                                if (!d) return null;
+                                return (
+                                    <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs shadow">
+                                        <p className="text-slate-600">受給開始: {formatAge(d.x)}</p>
+                                        <p className="font-medium text-slate-900">損益分岐: {formatAge(d.y)}</p>
+                                    </div>
+                                );
+                            }}
+                        />
+                        {/* 65歳受給開始の基準線 */}
+                        <ReferenceLine x={65} stroke="#94a3b8" strokeDasharray="4 4" label={{ value: "65歳", position: "top", fontSize: 11, fill: "#94a3b8" }} />
+                        <Scatter
+                            data={plotData}
+                            shape={(props: { cx?: number; cy?: number }) => (
+                                <circle cx={props.cx} cy={props.cy} r={2} fill="#1e40af" opacity={0.8} />
+                            )}
+                        />
+                    </ScatterChart>
+                </ResponsiveContainer>
+            </div>
+            {hiddenCount > 0 && (
+                <p className="text-xs text-slate-500">
+                    ※ {hiddenCount}パターンは100歳までに損益分岐点に到達しないため非表示です。
+                </p>
+            )}
+        </div>
+    );
+}

--- a/src/components/pension/PensionOutput.tsx
+++ b/src/components/pension/PensionOutput.tsx
@@ -2,6 +2,7 @@
 
 import { formatYen } from "@/lib/format-yen";
 import { AGE_STANDARD, type MonthlyResult } from "@/lib/calculations";
+import Link from "next/link";
 import { AGE_END } from "./pension-defaults";
 
 export type PensionOutputProps = {
@@ -19,7 +20,12 @@ export function PensionOutput({ breakevenLabel, takeAhead, lateDelay, startAgeYe
             <h2 className="mb-4 text-lg font-medium text-slate-800">出力</h2>
             <dl className="grid gap-3 text-sm">
                 <div className="border-b border-slate-100 py-2">
-                    <dt className="text-slate-600">損益分岐（完全逆転）</dt>
+                    <dt className="flex items-center gap-2 text-slate-600">
+                        損益分岐（完全逆転）
+                        <Link href="/breakeven" className="text-xs text-blue-600 underline hover:text-blue-800">
+                            全年齢を見る →
+                        </Link>
+                    </dt>
                     <dd className="mt-1 font-medium text-slate-900">{breakevenLabel}</dd>
                 </div>
                 {startAgeYears < AGE_STANDARD && (

--- a/src/components/pension/PensionSimulator.tsx
+++ b/src/components/pension/PensionSimulator.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { AGE_END, AGE_STANDARD, AGE_START, annualAt65FromInput, applyFamilyPreset, buildChartRows, earlyTakeAheadAmount, findBreakdownMonth, findBreakevenMonth, lateDelayForegoneAmount, pensionAnnualFactor, runScenario, type FamilyPreset, type UserInput } from "@/lib/calculations";
+import { usePensionInput } from "@/lib/pension-input-context";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { PensionBreakdown } from "./PensionBreakdown";
 import { PensionChart } from "./PensionChart";
@@ -8,19 +9,20 @@ import { PensionDisclaimers } from "./PensionDisclaimers";
 import { PensionForm } from "./PensionForm";
 import { PensionHeader } from "./PensionHeader";
 import { PensionOutput } from "./PensionOutput";
-import { defaultPensionInput } from "./pension-defaults";
 
 export function PensionSimulator() {
-    const [preset, setPreset] = useState<FamilyPreset>("single");
-    const [basic, setBasic] = useState(defaultPensionInput.pension.basic);
-    const [employee, setEmployee] = useState(defaultPensionInput.pension.employee);
-    const [spousePension, setSpousePension] = useState(defaultPensionInput.pension.spousePension ?? 0);
+    const {
+        preset, setPreset,
+        basic, setBasic,
+        employee, setEmployee,
+        spousePension, setSpousePension,
+        spouseIncome, setSpouseIncome,
+        householdSize, setHouseholdSize,
+        lifeInsurance, setLifeInsurance,
+        medicalExpense, setMedicalExpense,
+        startAgeMonths, setStartAgeMonths,
+    } = usePensionInput();
     const hasSpouse = preset !== "single";
-    const [spouseIncome, setSpouseIncome] = useState(defaultPensionInput.family.spouseIncome);
-    const [householdSize, setHouseholdSize] = useState(defaultPensionInput.family.householdSize);
-    const [lifeInsurance, setLifeInsurance] = useState(defaultPensionInput.insurance.lifeInsurance);
-    const [medicalExpense, setMedicalExpense] = useState(defaultPensionInput.insurance.medicalExpense);
-    const [startAgeMonths, setStartAgeMonths] = useState(AGE_STANDARD * 12);
     const [showBreakeven, setShowBreakeven] = useState(false);
     const breakevenTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 

--- a/src/lib/calculations.ts
+++ b/src/lib/calculations.ts
@@ -303,6 +303,40 @@ export function lateDelayForegoneAmount(
     return results65[idx]!.cumulativeNet - resultsSlide[idx]!.cumulativeNet;
 }
 
+export type BreakevenPoint = {
+    startAgeYears: number;
+    /** null = 100歳までに逆転しない */
+    breakevenAgeYears: number | null;
+};
+
+/** 全受給開始年齢（60〜75歳・月単位、計181パターン）の損益分岐点を一括算出 */
+export function computeAllBreakevens(
+    input: Omit<UserInput, "startAgeYears">,
+    annual65: number,
+): BreakevenPoint[] {
+    const results65 = runScenario({ ...input, startAgeYears: AGE_STANDARD }, AGE_STANDARD, annual65);
+    const cum65 = results65.map((r) => r.cumulativeNet);
+    const points: BreakevenPoint[] = [];
+    for (let m = AGE_START * 12; m <= 75 * 12; m++) {
+        const startAgeYears = m / 12;
+        const resultsSlide = runScenario({ ...input, startAgeYears }, startAgeYears, annual65);
+        const cumSlide = resultsSlide.map((r) => r.cumulativeNet);
+        let idx: number | null;
+        if (startAgeYears === AGE_STANDARD) {
+            idx = null;
+        } else if (startAgeYears < AGE_STANDARD) {
+            idx = findBreakdownMonth(cumSlide, cum65);
+        } else {
+            idx = findBreakevenMonth(cumSlide, cum65);
+        }
+        points.push({
+            startAgeYears,
+            breakevenAgeYears: idx !== null ? AGE_START + idx / 12 : null,
+        });
+    }
+    return points;
+}
+
 export function buildChartRows(results65: MonthlyResult[], resultsSlide: MonthlyResult[]): { age: number; cumulative65: number; cumulativeSlide: number }[] {
     const rows: { age: number; cumulative65: number; cumulativeSlide: number }[] = [];
     for (let i = 0; i < results65.length; i++) {

--- a/src/lib/pension-input-context.tsx
+++ b/src/lib/pension-input-context.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { createContext, useContext, useState } from "react";
+import { AGE_STANDARD, type FamilyPreset } from "@/lib/calculations";
+import { defaultPensionInput } from "@/components/pension/pension-defaults";
+
+type PensionInputContextType = {
+    preset: FamilyPreset;
+    setPreset: (v: FamilyPreset) => void;
+    basic: number;
+    setBasic: (v: number) => void;
+    employee: number;
+    setEmployee: (v: number) => void;
+    spousePension: number;
+    setSpousePension: (v: number) => void;
+    spouseIncome: number;
+    setSpouseIncome: (v: number) => void;
+    householdSize: number;
+    setHouseholdSize: (v: number) => void;
+    lifeInsurance: number;
+    setLifeInsurance: (v: number) => void;
+    medicalExpense: number;
+    setMedicalExpense: (v: number) => void;
+    startAgeMonths: number;
+    setStartAgeMonths: (v: number) => void;
+};
+
+const PensionInputContext = createContext<PensionInputContextType | null>(null);
+
+export function PensionInputProvider({ children }: { children: React.ReactNode }) {
+    const [preset, setPreset] = useState<FamilyPreset>("single");
+    const [basic, setBasic] = useState(defaultPensionInput.pension.basic);
+    const [employee, setEmployee] = useState(defaultPensionInput.pension.employee);
+    const [spousePension, setSpousePension] = useState(defaultPensionInput.pension.spousePension ?? 0);
+    const [spouseIncome, setSpouseIncome] = useState(defaultPensionInput.family.spouseIncome);
+    const [householdSize, setHouseholdSize] = useState(defaultPensionInput.family.householdSize);
+    const [lifeInsurance, setLifeInsurance] = useState(defaultPensionInput.insurance.lifeInsurance);
+    const [medicalExpense, setMedicalExpense] = useState(defaultPensionInput.insurance.medicalExpense);
+    const [startAgeMonths, setStartAgeMonths] = useState(AGE_STANDARD * 12);
+
+    return (
+        <PensionInputContext.Provider
+            value={{
+                preset,
+                setPreset,
+                basic,
+                setBasic,
+                employee,
+                setEmployee,
+                spousePension,
+                setSpousePension,
+                spouseIncome,
+                setSpouseIncome,
+                householdSize,
+                setHouseholdSize,
+                lifeInsurance,
+                setLifeInsurance,
+                medicalExpense,
+                setMedicalExpense,
+                startAgeMonths,
+                setStartAgeMonths,
+            }}
+        >
+            {children}
+        </PensionInputContext.Provider>
+    );
+}
+
+export function usePensionInput(): PensionInputContextType {
+    const ctx = useContext(PensionInputContext);
+    if (!ctx) throw new Error("usePensionInput は PensionInputProvider の内側で使用してください");
+    return ctx;
+}


### PR DESCRIPTION
### 概要

受給開始年齢ごとの損益分岐点を一覧表示する `/breakeven` ページを追加する。
入力値の共有には React Context を導入し、メインページの設定をそのままページ遷移先で参照できるようにした。

### 背景

現状、損益分岐点はスライダーで選択した1つの受給開始年齢に対してのみ表示されている。
60〜75歳の全パターンを俯瞰したいという要望に対応するため、専用ページを設ける。
Issue #44

### 変更内容

- `src/lib/pension-input-context.tsx`（新規）  
  年金入力フォームの全状態（年金額・家族構成・控除・受給開始月）を React Context で管理する `PensionInputProvider` / `usePensionInput` を追加。

- `src/app/layout.tsx`  
  `PensionInputProvider` でアプリ全体をラップし、全ページから入力値を参照可能にした。

- `src/components/pension/PensionSimulator.tsx`  
  ローカルの `useState` 群を `usePensionInput()` に置き換え。計算ロジックと JSX は変更なし。

- `src/lib/calculations.ts`  
  `BreakevenPoint` 型と `computeAllBreakevens` 関数を追加。60〜75歳・月単位の全181パターンについて、65歳開始との損益分岐点を一括算出する。

- `src/components/pension/BreakevenAllChart.tsx`（新規）  
  recharts `ScatterChart` を使った散布図コンポーネント。横軸に受給開始年齢（60〜75歳・1歳刻み）、縦軸に損益分岐年齢（75〜95歳）、65歳の基準線を点線で表示。100歳までに逆転しないパターンはドット非表示・件数を注記。

- `src/app/breakeven/page.tsx`（新規）  
  `/breakeven` ルート。`usePensionInput()` で入力値を取得し `useEffect` 内で全パターン計算。計算完了までスピナーを表示し、完了後に `BreakevenAllChart` を描画する。入力値サマリーと「← シミュレーターに戻る」リンクを付属。

- `src/components/pension/PensionOutput.tsx`  
  「損益分岐（完全逆転）」行のタイトル横に「全年齢を見る →」リンクを追加。

### 動作確認

- [x] `npm run build` でエラーなし
- [x] メインページの損益分岐行に「全年齢を見る →」リンクが表示される
- [x] クリックで `/breakeven` に遷移し、スピナー表示後にドットチャートが描画される
- [x] フォームで入力値を変更後に遷移するとチャートに反映される
- [x] 100歳まで逆転しないパターンのドットが非表示になっている