### PR TITLE
fix: 損益分岐点ページ遷移時のローディングを追加

### DIFF
--- a/src/app/breakeven/loading.tsx
+++ b/src/app/breakeven/loading.tsx
@@ -1,0 +1,9 @@
+export default function Loading() {
+    return (
+        <div className="mx-auto max-w-5xl px-4 py-10">
+            <div className="flex h-[420px] items-center justify-center">
+                <div className="h-8 w-8 animate-spin rounded-full border-4 border-slate-200 border-t-slate-700" />
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
### 概要

`/breakeven` ページへの遷移時、クリック直後にローディングスピナーを表示するようにする。

### 背景

「全年齢を見る →」リンクをクリックしてからページが表示されるまでラグがあり、UX が悪い状態だった（#47）。
Next.js App Router はルートセグメントの JS チャンクを遅延ロードするため、バンドルのダウンロード中は画面が変わらず無反応に見える。

### 変更内容

- `src/app/breakeven/loading.tsx` を新規作成
  - Next.js App Router の規約ファイル。存在するだけでページ読み込み中の Suspense fallback として機能する。
  - クリック直後から既存の spinner デザイン（`border-t-slate-700`）と同じローディング UI を表示する。

### 動作確認

- [x] `npm run build` でエラーなし
- [x] メインページの「全年齢を見る →」をクリックし、即座にスピナーが表示されることを確認
- [x] スピナー表示後、チャートが正常に描画されることを確認